### PR TITLE
Fix dummy app creation and test rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
+gem 'rails-controller-testing'
+
 gemspec


### PR DESCRIPTION
1. To create the dummy application
`bundle exec rake test_app`
2. To run the rspec test
`bundle exec rspec spec`

Fix for issue #1 